### PR TITLE
More Config-Options for the String-Constant generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Sesame Vocabulary Builder provides a command line tool and maven plugin that all
                                         (empty) package if absent
   -s,--spaces <indent>                  use spaces for indentation (tabs if
                                         missing, 4 spaces if no number given)
+  -S,--stringConstantSuffix <suffix>    suffix to create string constants (e.g.
+                                        _STRING
   -u,--uri <prefix>                     the prefix for the vocabulary (if not
                                         available in the input file)
 ```
@@ -63,6 +65,7 @@ Sesame Vocabulary Builder provides a command line tool and maven plugin that all
                 <constantCase>UPPER_UNDERSCORE</constantCase>
                 <createStringConstants>true</createStringConstants>
                 <stringConstantPrefix>_</stringConstantPrefix>
+                <stringConstantSuffix>_STRING</stringConstantSuffix>
                 <vocabularies>
                     <vocabulary>
                         <className>LDP</className>

--- a/README.md
+++ b/README.md
@@ -5,38 +5,46 @@ Sesame Vocabulary Builder provides a command line tool and maven plugin that all
 ## How To
 
 1. Download the latest version [here](https://github.com/tkurz/sesame-vocab-builder/releases).
-2. Run jar from command line (Java 7 required): `java -jar vocab-builder-cli-{VERSION}-exe.jar <input-file> [<output-file>]`
-3. Additional information can be configured using command-line parameters
+1. Run jar from command line (Java 7 required): `java -jar vocab-builder-cli-{VERSION}-exe.jar <input-file> [<output-file>]`
+1. Additional information can be configured using command-line parameters
 
 ## Command Line Options
 
 ```
-  <input-file>                          the input file to read from
-  [<output-file>]                       the output file to write, StdOut if
-                                        omitted
-  -b,--languageBundles                  generate L10N LanguageBundles
-  -c,--constantCase <prefConstantCase>  case to use for URI constants
-  -f,--format <input-format>            mime-type of the input file (will try to
-                                        guess if absent)
-  -h,--help                             print this help
-  -l,--language <prefLang>              preferred language for vocabulary labels
-  -n,--name <ns>                        the name of the namespace (will try to
-                                        guess from the input file if absent)
-  -p,--package <package>                package declaration (will use default
-                                        (empty) package if absent
-  -s,--spaces <indent>                  use spaces for indentation (tabs if
-                                        missing, 4 spaces if no number given)
-  -S,--stringConstantSuffix <suffix>    suffix to create string constants (e.g.
-                                        _STRING
-  -u,--uri <prefix>                     the prefix for the vocabulary (if not
-                                        available in the input file)
+  <input-file>                            the input file to read from
+  [<output-file>]                         the output file to write, StdOut if
+                                          omitted
+  -b,--languageBundles                    generate L10N LanguageBundles
+  -c,--constantCase <constantCase>        case to use for URI constants,
+                                          possible values: LOWER_UNDERSCORE,
+                                          LOWER_CAMEL, UPPER_CAMEL,
+                                          UPPER_UNDERSCORE
+  -C,--stringConstantCase <constantCase>  case to use for String constants, see
+                                          constantCase
+  -f,--format <input-format>              mime-type of the input file (will try
+                                          to guess if absent)
+  -h,--help                               print this help
+  -l,--language <prefLang>                preferred language for vocabulary
+                                          labels
+  -n,--name <ns>                          the name of the namespace (will try to
+                                          guess from the input file if absent)
+  -P,--stringConstantPrefix <prefix>      prefix to create string constants
+                                          (e.g. _)
+  -p,--package <package>                  package declaration (will use default
+                                          (empty) package if absent)
+  -s,--spaces <indent>                    use spaces for indentation (tabs if
+                                          missing, 4 spaces if no number given)
+  -S,--stringConstantSuffix <suffix>      suffix to create string constants
+                                          (e.g. _STRING)
+  -u,--uri <prefix>                       the prefix for the vocabulary (if not
+                                          available in the input file)
 ```
 
 ## Run from Git
 
 1. Clone from https://github.com/tkurz/sesame-vocab-builder.git
-2. Run `./sesame-vocab-builder  <input-file> <output-file>`
-3. Additional information can be configured using command-line parameters
+1. Run `./sesame-vocab-builder  <input-file> <output-file>`
+1. Additional information can be configured using command-line parameters
 
 ## Maven Plugin
 
@@ -64,6 +72,7 @@ Sesame Vocabulary Builder provides a command line tool and maven plugin that all
                 <createResourceBundles>true</createResourceBundles>
                 <constantCase>UPPER_UNDERSCORE</constantCase>
                 <createStringConstants>true</createStringConstants>
+                <stringConstantCase>UPPER_UNDERSCORE</stringConstantCase>
                 <stringConstantPrefix>_</stringConstantPrefix>
                 <stringConstantSuffix>_STRING</stringConstantSuffix>
                 <vocabularies>

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -105,13 +105,29 @@ public class Main {
             } else {
                 builder.setStringPropertySuffix(null);
             }
+            if (cli.hasOption('P')) {
+                builder.setStringPropertyPrefix(cli.getOptionValue('P'));
+            } else {
+                builder.setStringPropertyPrefix(null);
+            }
             if (cli.hasOption('c')) {
                 try {
-                    CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
+                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
                     if (caseFormat == null) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
                     builder.setConstantCase(caseFormat);
+                } catch (IllegalArgumentException e) {
+                    throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+                }
+            }
+            if (cli.hasOption('C')) {
+                try {
+                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
+                    if (caseFormat == null) {
+                        throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+                    }
+                    builder.setStringConstantCase(caseFormat);
                 } catch (IllegalArgumentException e) {
                     throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                 }
@@ -258,11 +274,26 @@ public class Main {
                 .create('c'));
 
         o.addOption(OptionBuilder
+                .withLongOpt("stringConstantCase")
+                .withDescription("case to use for String constants")
+                .hasArgs(1)
+                .withArgName("prefConstantCase")
+                .isRequired(false)
+                .create('C'));
+
+        o.addOption(OptionBuilder
                 .withLongOpt("stringConstantSuffix")
                 .withDescription("suffix to create string constants (e.g. _STRING")
                 .hasArgs(1)
                 .withArgName("suffix")
                 .create('S'));
+
+        o.addOption(OptionBuilder
+                .withLongOpt("stringConstantPrefix")
+                .withDescription("prefix to create string constants (e.g. _")
+                .hasArgs(1)
+                .withArgName("prefix")
+                .create('P'));
 
         o.addOption(OptionBuilder
                 .withLongOpt("help")

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -101,9 +101,9 @@ public class Main {
                 builder.setPreferredLanguage(cli.getOptionValue('l'));
             }
             if (cli.hasOption('S')) {
-                builder.setStringPropertyPrefix(cli.getOptionValue('S'));
+                builder.setStringPropertySuffix(cli.getOptionValue('S'));
             } else {
-                builder.setStringPropertyPrefix(null);
+                builder.setStringPropertySuffix(null);
             }
             if (cli.hasOption('c')) {
                 try {
@@ -258,10 +258,10 @@ public class Main {
                 .create('c'));
 
         o.addOption(OptionBuilder
-                .withLongOpt("stringConstantPrefix")
-                .withDescription("prefix to create string constants")
+                .withLongOpt("stringConstantSuffix")
+                .withDescription("suffix to create string constants (e.g. _STRING")
                 .hasArgs(1)
-                .withArgName("prefix")
+                .withArgName("suffix")
                 .create('S'));
 
         o.addOption(OptionBuilder

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -199,8 +199,8 @@ public class Main {
             w.println();
         }
         hf.printWrapped(w, 80, 12, "usage: Main [options...] <input-file> [<output-file>]");
-        hf.printWrapped(w, 80, 40, "  <input-file>                          the input file to read from");
-        hf.printWrapped(w, 80, 40, "  [<output-file>]                       the output file to write, StdOut if omitted");
+        hf.printWrapped(w, 80, 42, "  <input-file>                            the input file to read from");
+        hf.printWrapped(w, 80, 42, "  [<output-file>]                         the output file to write, StdOut if omitted");
         hf.printOptions(w, 80, getCliOpts(), 2, 2);
         w.flush();
         w.close();
@@ -220,7 +220,7 @@ public class Main {
 
         o.addOption(OptionBuilder
                 .withLongOpt("package")
-                .withDescription("package declaration (will use default (empty) package if absent")
+                .withDescription("package declaration (will use default (empty) package if absent)")
                 .hasArgs(1)
                 .withArgName("package")
                 .isRequired(false)
@@ -267,30 +267,30 @@ public class Main {
 
         o.addOption(OptionBuilder
                 .withLongOpt("constantCase")
-                .withDescription("case to use for URI constants")
+                .withDescription("case to use for URI constants, possible values: LOWER_UNDERSCORE, LOWER_CAMEL, UPPER_CAMEL, UPPER_UNDERSCORE")
                 .hasArgs(1)
-                .withArgName("prefConstantCase")
+                .withArgName("constantCase")
                 .isRequired(false)
                 .create('c'));
 
         o.addOption(OptionBuilder
                 .withLongOpt("stringConstantCase")
-                .withDescription("case to use for String constants")
+                .withDescription("case to use for String constants, see constantCase")
                 .hasArgs(1)
-                .withArgName("prefConstantCase")
+                .withArgName("constantCase")
                 .isRequired(false)
                 .create('C'));
 
         o.addOption(OptionBuilder
                 .withLongOpt("stringConstantSuffix")
-                .withDescription("suffix to create string constants (e.g. _STRING")
+                .withDescription("suffix to create string constants (e.g. _STRING)")
                 .hasArgs(1)
                 .withArgName("suffix")
                 .create('S'));
 
         o.addOption(OptionBuilder
                 .withLongOpt("stringConstantPrefix")
-                .withDescription("prefix to create string constants (e.g. _")
+                .withDescription("prefix to create string constants (e.g. _)")
                 .hasArgs(1)
                 .withArgName("prefix")
                 .create('P'));

--- a/vocab-builder-core/pom.xml
+++ b/vocab-builder-core/pom.xml
@@ -98,5 +98,10 @@
             <artifactId>semargl-sesame</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
@@ -51,7 +51,7 @@ public class VocabBuilder {
     private String language = null;
     private final Model model;
     private CaseFormat caseFormat;
-    private String stringPropertyPrefix;
+    private String stringPropertyPrefix, stringPropertySuffix;
     private static Set<String> reservedWords = Sets.newHashSet("abstract","assert","boolean","break","byte","case","catch","char","class","const","default","do","double","else","enum","extends","false","final","finally","float","for","goto","if","implements","import","instanceof","int","interface","long","native","new","null","package","private","protected","public","return","short","static","strictfp","super","switch","synchronized","this","throw","throws","transient","true","try","void","volatile","while","continue","PREFIX","NAMESPACE");
     /**
      * Create a new VocabularyBuilder, reading the vocab definition from the provided file
@@ -183,11 +183,40 @@ public class VocabBuilder {
         out.printf(getIndent(1) + "public static final String PREFIX = \"%s\";%n", name.toLowerCase());
         out.println();
 
-        //and now the resources
         List<String> keys = new ArrayList<>();
         keys.addAll(splitUris.keySet());
         Collections.sort(keys, String.CASE_INSENSITIVE_ORDER);
 
+        //string constant values
+        if (((stringPropertyPrefix != null) && (stringPropertyPrefix.length() > 0))
+                || ((stringPropertySuffix != null) && (stringPropertySuffix.length() > 0))) {
+            // add the possibility to add a string property with the namespace for usage in
+            for (String key : keys) {
+                Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
+                Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
+
+                out.println(getIndent(1) + "/**");
+                if (label != null) {
+                    out.printf(getIndent(1) + " * %s%n", label.getLabel());
+                    out.println(getIndent(1) + " * <p>");
+                }
+                out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
+                if (comment != null) {
+                    out.println(getIndent(1) + " * <p>");
+                    out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n\t * ", false));
+                }
+                out.println(getIndent(1) + " *");
+                out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
+                out.println(getIndent(1) + " */");
+
+                String nextKey = cleanKey(doCaseFormatting(key, CaseFormat.UPPER_UNDERSCORE));
+                out.printf(getIndent(1) + "public static final String %s%s%s = %s.NAMESPACE + \"%s\";%n",
+                        StringUtils.defaultString(stringPropertyPrefix), nextKey, StringUtils.defaultString(stringPropertySuffix), className, key);
+                out.println();
+            }
+        }
+
+        //and now the resources
         for (String key : keys) {
             Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
             Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
@@ -208,25 +237,6 @@ public class VocabBuilder {
 
             String nextKey = cleanKey(doCaseFormatting(key));
             out.printf(getIndent(1) + "public static final URI %s;%n", nextKey);
-            // add the possibility to add a string property with the namespace for usage in
-            // 
-            if (stringPropertyPrefix!=null && stringPropertyPrefix.length() > 0 ) {
-                out.println(getIndent(1) + "/**");
-                if (label != null) {
-                    out.printf(getIndent(1) + " * %s%n", label.getLabel());
-                    out.println(getIndent(1) + " * <p>");
-                }
-                out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
-                if (comment != null) {
-                    out.println(getIndent(1) + " * <p>");
-                    out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n\t * ", false));
-                }
-                out.println(getIndent(1) + " *");
-                out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
-                out.println(getIndent(1) + " */");
-
-            	out.printf(getIndent(1) + "public static final String %s = %s + \"%s\";%n", stringPropertyPrefix + nextKey, className + ".NAMESPACE", key );
-            }
             out.println();
         }
 
@@ -236,7 +246,7 @@ public class VocabBuilder {
         out.println();
         for (String key : keys) {
             String nextKey = cleanKey(doCaseFormatting(key));
-            out.printf(getIndent(2) + "%s = factory.createURI(%s, \"%s\");%n", nextKey, className + ".NAMESPACE", key);
+            out.printf(getIndent(2) + "%s = factory.createURI(%s.NAMESPACE, \"%s\");%n", nextKey, className, key);
         }
         out.println(getIndent(1) + "}");
         out.println();
@@ -404,7 +414,11 @@ public class VocabBuilder {
     }
 
     private String doCaseFormatting(String key) {
-        if (caseFormat == null) {
+        return doCaseFormatting(key, caseFormat);
+    }
+
+    private String doCaseFormatting(String key, CaseFormat targetFormat) {
+        if (targetFormat == null) {
             return key;
         } else {
             CaseFormat originalFormat = CaseFormat.LOWER_CAMEL;
@@ -417,7 +431,7 @@ public class VocabBuilder {
             } else if (key.contains("-")) {
                 originalFormat = CaseFormat.LOWER_HYPHEN;
             }
-            return originalFormat.to(caseFormat, key);
+            return originalFormat.to(targetFormat, key);
         }
     }
 
@@ -469,11 +483,19 @@ public class VocabBuilder {
         return caseFormat;
     }
 
-	public String getStringPropertyPrefix() {
-		return stringPropertyPrefix;
+    public String getStringPropertyPrefix() {
+        return stringPropertyPrefix;
+    }
+
+    public void setStringPropertyPrefix(String stringPropertyPrefix) {
+        this.stringPropertyPrefix = stringPropertyPrefix;
+    }
+
+    public String getStringPropertySuffix() {
+		return stringPropertySuffix;
 	}
 
-	public void setStringPropertyPrefix(String stringPropertyPrefix) {
-		this.stringPropertyPrefix = stringPropertyPrefix;
+	public void setStringPropertySuffix(String stringPropertySuffix) {
+		this.stringPropertySuffix = stringPropertySuffix;
 	}
 }

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/AbstractVocabSpecificTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/AbstractVocabSpecificTest.java
@@ -1,0 +1,67 @@
+package com.github.tkurz.sesame.vocab.test;
+
+
+import com.github.tkurz.sesame.vocab.GenerationException;
+import com.github.tkurz.sesame.vocab.VocabBuilder;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openrdf.model.util.GraphUtilException;
+import org.openrdf.rio.RDFFormat;
+import org.openrdf.rio.RDFParseException;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public abstract class AbstractVocabSpecificTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private Path output;
+
+    @Before
+    public void setUp() throws IOException {
+        File input = temp.newFile(String.format("%s.%s", getBasename(), getFormat().getDefaultFileExtension()));
+        FileUtils.copyInputStreamToFile(getInputStream(), input);
+
+        output = temp.newFile(String.format("%S.java", getBasename())).toPath();
+
+        try {
+            VocabBuilder vb = new VocabBuilder(input.getAbsolutePath(), getFormat());
+            vb.generate(output);
+            System.out.println(output);
+        } catch (GenerationException e) {
+            Assert.fail("Could not generate vocab " + e.getMessage());
+        } catch (RDFParseException e) {
+            Assert.fail("Could not parse test-file: " + e.getMessage());
+        } catch (GraphUtilException e) {
+            Assert.fail("Could not read vocabulary: " + e.getMessage());
+        }
+
+    }
+
+    protected abstract InputStream getInputStream();
+
+    protected abstract String getBasename();
+
+    protected abstract RDFFormat getFormat();
+
+    @Test
+    public void testCompilation() {
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+        int result = compiler.run(null, null, null, output.toString());
+        Assert.assertEquals("Compiling the Vocab failed", 0, result);
+
+    }
+
+
+}

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/vocabularies/FoafVocabTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/vocabularies/FoafVocabTest.java
@@ -1,0 +1,32 @@
+package com.github.tkurz.sesame.vocab.test.vocabularies;
+
+import com.github.tkurz.sesame.vocab.test.AbstractVocabSpecificTest;
+import org.junit.Assume;
+import org.openrdf.rio.RDFFormat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class FoafVocabTest extends AbstractVocabSpecificTest {
+
+    @Override
+    protected InputStream getInputStream() {
+        try {
+            return new URL("http://xmlns.com/foaf/spec/index.rdf").openStream();
+        } catch (IOException e) {
+            Assume.assumeNoException(e);
+            return null;
+        }
+    }
+
+    @Override
+    protected String getBasename() {
+        return "foaf";
+    }
+
+    @Override
+    protected RDFFormat getFormat() {
+        return RDFFormat.RDFXML;
+    }
+}

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -95,6 +95,9 @@ public class VocabularyBuilderMojo extends AbstractMojo {
     @Parameter(property = "constantCase")
     private CaseFormat constantCase;
 
+    @Parameter(property = "stringConstantCase", defaultValue = "UPPER_UNDERSCORE")
+    private CaseFormat stringConstantCase;
+
     @Parameter(property = "project", required = true, readonly = true)
     private MavenProject project;
 
@@ -248,10 +251,12 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                         // when no string constant prefix set, use a single underscore by default
                         builder.setStringPropertyPrefix(stringConstantPrefix);
                         builder.setStringPropertySuffix(stringConstantSuffix);
+                        builder.setStringConstantCase(stringConstantCase);
                     } else {
                         // be sure to not generate String constants
                         builder.setStringPropertyPrefix(null);
                         builder.setStringPropertySuffix(null);
+                        builder.setStringConstantCase(null);
                     }
                     final Path vFile = target.resolve(fName);
                     final String className = vFile.getFileName().toString().replaceFirst("\\.java$", "");

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -85,11 +85,13 @@ public class VocabularyBuilderMojo extends AbstractMojo {
     @Parameter(property = "createResourceBundles", defaultValue = "false")
     private boolean createResourceBundles;
 
-    @Parameter(property = "createStringConstants", defaultValue = "false")
+    @Parameter(property = "createStringConstants", defaultValue = "true")
     private boolean createStringConstants;
-    @Parameter(property = "stringConstantPrefix")
+    @Parameter(property = "stringConstantPrefix", defaultValue = "")
     private String stringConstantPrefix;
-    
+    @Parameter(property = "stringConstantSuffix", defaultValue = "_STRING")
+    private String stringConstantSuffix;
+
     @Parameter(property = "constantCase")
     private CaseFormat constantCase;
 
@@ -223,7 +225,7 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                     if (vocab.getPrefix() != null) {
                         builder.setPrefix(vocab.getPrefix());
                     }
-                    
+
                     builder.setName(vocab.getName());
 
                     String fName;
@@ -240,15 +242,16 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                         target = target.resolve(builder.getPackageName().replaceAll("\\.", "/"));
                         Files.createDirectories(target);
                     }
-                    // when string constant generation set, specify a prefix
-                    if ( createStringConstants ) {
-                    	// when prefix set, the builder will generate string constants in addition to the URI's
-                    	// when no string constant prefix set, use a single underscore by default
-                    	builder.setStringPropertyPrefix((stringConstantPrefix==null? "_": stringConstantPrefix));
-                    }
-                    else {
-                    	// be sure to not generate String constants
-                    	builder.setStringPropertyPrefix(null);
+                    // when string constant generation set, specify prefix and suffix
+                    if (createStringConstants) {
+                        // when prefix set, the builder will generate string constants in addition to the URI's
+                        // when no string constant prefix set, use a single underscore by default
+                        builder.setStringPropertyPrefix(stringConstantPrefix);
+                        builder.setStringPropertySuffix(stringConstantSuffix);
+                    } else {
+                        // be sure to not generate String constants
+                        builder.setStringPropertyPrefix(null);
+                        builder.setStringPropertySuffix(null);
                     }
                     final Path vFile = target.resolve(fName);
                     final String className = vFile.getFileName().toString().replaceFirst("\\.java$", "");


### PR DESCRIPTION
With these changes, one can define a `prefix` and a `suffix` for the string constanty, resulting in constants like `RDFS.CLASS_STRING`.

Enabled String-Constant generation by default for the maven-plugin.

Also, the String constants are now placed before the URI constants (just cosmetics).
