### PR TITLE
remove "default" CaseFormat for stringConstants!

### DIFF
--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -217,7 +217,7 @@ public class Main {
         w.close();
     }
 
-    @SuppressWarnings({"AccessStaticViaInstance", "static-access"})
+    @SuppressWarnings({"static-access"})
     private static Options getCliOpts() {
         Options o = new Options();
 

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -103,12 +103,13 @@ public class Main {
             CaseFormat caseFormat = null;
             final GenerationSetting uriGenerationSetting = new GenerationSetting(); 
             if (cli.hasOption('c')) {
+            	String uriCaseFormat = cli.getOptionValue('c');
+            	uriGenerationSetting.setCaseFormat(uriCaseFormat);
                 try {
                     caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
                     if (caseFormat == null) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
-                    uriGenerationSetting.setCaseFormat(caseFormat);
                 } catch (IllegalArgumentException e) {
                     throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                 }
@@ -126,19 +127,19 @@ public class Main {
             		setting.setConstantSuffix(cli.getOptionValue('S'));
             	}
                 if (cli.hasOption('C')) {
+                	setting.setCaseFormat(cli.getOptionValue('C'));
                     try {
                         final CaseFormat strCaseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
                         if (caseFormat == null) {
                             throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                         }
-                        setting.setCaseFormat(strCaseFormat);
                     } catch (IllegalArgumentException e) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
                 }
                 else {
                 	// uri case format applies as DEFAULT
-                	setting.setCaseFormat(caseFormat);
+                	setting.setCaseFormat("NONE");
                 }
                 // specify string generation
             	builder.setStringGeneration(setting);

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -143,38 +143,6 @@ public class Main {
                 // specify string generation
             	builder.setStringGeneration(setting);
             }
-//            if (cli.hasOption('S')) {
-//                builder.setStringPropertySuffix(cli.getOptionValue('S'));
-//            } else {
-//                builder.setStringPropertySuffix(null);
-//            }
-//            if (cli.hasOption('P')) {
-//                builder.setStringPropertyPrefix(cli.getOptionValue('P'));
-//            } else {
-//                builder.setStringPropertyPrefix(null);
-//            }
-//            if (cli.hasOption('c')) {
-//                try {
-//                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
-//                    if (caseFormat == null) {
-//                        throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
-//                    }
-//                    builder.setConstantCase(caseFormat);
-//                } catch (IllegalArgumentException e) {
-//                    throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
-//                }
-//            }
-//            if (cli.hasOption('C')) {
-//                try {
-//                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
-//                    if (caseFormat == null) {
-//                        throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
-//                    }
-//                    builder.setStringConstantCase(caseFormat);
-//                } catch (IllegalArgumentException e) {
-//                    throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
-//                }
-//            }
             if (cli.hasOption('s')) {
                 try {
                     builder.setIndent(StringUtils.repeat(' ', Integer.parseInt(cli.getOptionValue('s', "4"))));

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -100,38 +100,81 @@ public class Main {
             if (cli.hasOption('l')) {
                 builder.setPreferredLanguage(cli.getOptionValue('l'));
             }
-            if (cli.hasOption('S')) {
-                builder.setStringPropertySuffix(cli.getOptionValue('S'));
-            } else {
-                builder.setStringPropertySuffix(null);
-            }
-            if (cli.hasOption('P')) {
-                builder.setStringPropertyPrefix(cli.getOptionValue('P'));
-            } else {
-                builder.setStringPropertyPrefix(null);
-            }
+            CaseFormat caseFormat = null;
+            final GenerationSetting uriGenerationSetting = new GenerationSetting(); 
             if (cli.hasOption('c')) {
                 try {
-                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
+                    caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
                     if (caseFormat == null) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
-                    builder.setConstantCase(caseFormat);
+                    uriGenerationSetting.setCaseFormat(caseFormat);
                 } catch (IllegalArgumentException e) {
                     throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                 }
             }
-            if (cli.hasOption('C')) {
-                try {
-                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
-                    if (caseFormat == null) {
+            // in any case, do URI generation from the command line
+            builder.setUriGeneration(uriGenerationSetting);
+            
+            // options for string generation - when NO option present--> no string generation
+            if ( cli.hasOption('S') || cli.hasOption('P') || cli.hasOption('C')) {
+            	GenerationSetting setting = new GenerationSetting();
+            	if ( cli.hasOption('P')) {
+            		setting.setConstantPrefix(cli.getOptionValue('P'));
+            	}
+            	if ( cli.hasOption('S')) {
+            		setting.setConstantSuffix(cli.getOptionValue('S'));
+            	}
+                if (cli.hasOption('C')) {
+                    try {
+                        final CaseFormat strCaseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
+                        if (caseFormat == null) {
+                            throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+                        }
+                        setting.setCaseFormat(strCaseFormat);
+                    } catch (IllegalArgumentException e) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
-                    builder.setStringConstantCase(caseFormat);
-                } catch (IllegalArgumentException e) {
-                    throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                 }
+                else {
+                	// uri case format applies as DEFAULT
+                	setting.setCaseFormat(caseFormat);
+                }
+                // specify string generation
+            	builder.setStringGeneration(setting);
             }
+//            if (cli.hasOption('S')) {
+//                builder.setStringPropertySuffix(cli.getOptionValue('S'));
+//            } else {
+//                builder.setStringPropertySuffix(null);
+//            }
+//            if (cli.hasOption('P')) {
+//                builder.setStringPropertyPrefix(cli.getOptionValue('P'));
+//            } else {
+//                builder.setStringPropertyPrefix(null);
+//            }
+//            if (cli.hasOption('c')) {
+//                try {
+//                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
+//                    if (caseFormat == null) {
+//                        throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+//                    }
+//                    builder.setConstantCase(caseFormat);
+//                } catch (IllegalArgumentException e) {
+//                    throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+//                }
+//            }
+//            if (cli.hasOption('C')) {
+//                try {
+//                    final CaseFormat caseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
+//                    if (caseFormat == null) {
+//                        throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+//                    }
+//                    builder.setStringConstantCase(caseFormat);
+//                } catch (IllegalArgumentException e) {
+//                    throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
+//                }
+//            }
             if (cli.hasOption('s')) {
                 try {
                     builder.setIndent(StringUtils.repeat(' ', Integer.parseInt(cli.getOptionValue('s', "4"))));

--- a/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
+++ b/vocab-builder-cli/src/main/java/com/github/tkurz/sesame/vocab/Main.java
@@ -103,13 +103,12 @@ public class Main {
             CaseFormat caseFormat = null;
             final GenerationSetting uriGenerationSetting = new GenerationSetting(); 
             if (cli.hasOption('c')) {
-            	String uriCaseFormat = cli.getOptionValue('c');
-            	uriGenerationSetting.setCaseFormat(uriCaseFormat);
                 try {
                     caseFormat = CaseFormat.valueOf(cli.getOptionValue('c'));
                     if (caseFormat == null) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
+                    uriGenerationSetting.setCaseFormat(caseFormat);
                 } catch (IllegalArgumentException e) {
                     throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                 }
@@ -127,19 +126,19 @@ public class Main {
             		setting.setConstantSuffix(cli.getOptionValue('S'));
             	}
                 if (cli.hasOption('C')) {
-                	setting.setCaseFormat(cli.getOptionValue('C'));
                     try {
                         final CaseFormat strCaseFormat = CaseFormat.valueOf(cli.getOptionValue('C'));
                         if (caseFormat == null) {
                             throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                         }
+                        setting.setCaseFormat(strCaseFormat);
                     } catch (IllegalArgumentException e) {
                         throw new ParseException("Did not recognise constantCase: Must be one of " + Arrays.asList(CaseFormat.values()));
                     }
                 }
                 else {
                 	// uri case format applies as DEFAULT
-                	setting.setCaseFormat("NONE");
+                	setting.setCaseFormat(caseFormat);
                 }
                 // specify string generation
             	builder.setStringGeneration(setting);

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
@@ -4,19 +4,13 @@ import com.google.common.base.CaseFormat;
 
 public class GenerationSetting {
 
-	private String caseFormat;
+	private CaseFormat caseFormat;
 	private String constantPrefix;
 	private String constantSuffix;
 	public CaseFormat getCaseFormat() {
-		try {
-			if ( caseFormat != null ) {
-				return CaseFormat.valueOf(caseFormat);
-			}
-		} catch (Exception e) {
-		}
-		return null;
+		return caseFormat;
 	}
-	public void setCaseFormat(String caseFormat) {
+	public void setCaseFormat(CaseFormat caseFormat) {
 		this.caseFormat = caseFormat;
 	}
 	public String getConstantPrefix() {
@@ -33,13 +27,12 @@ public class GenerationSetting {
 	}
 	public static GenerationSetting createDefault(CaseFormat format, String prefix, String suffix) {
 		GenerationSetting setting = new GenerationSetting();
-		setting.caseFormat = (format != null ? format.name() : null);
+		setting.caseFormat = format;
 		setting.constantPrefix = prefix;
 		setting.constantSuffix = suffix;
 		return setting;
 		
 	}
-	
 	public GenerationSetting mergeWith(GenerationSetting other) {
 		if ( other == null) {
 			other = new GenerationSetting();

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
@@ -4,13 +4,19 @@ import com.google.common.base.CaseFormat;
 
 public class GenerationSetting {
 
-	private CaseFormat caseFormat;
+	private String caseFormat;
 	private String constantPrefix;
 	private String constantSuffix;
 	public CaseFormat getCaseFormat() {
-		return caseFormat;
+		try {
+			if ( caseFormat != null ) {
+				return CaseFormat.valueOf(caseFormat);
+			}
+		} catch (Exception e) {
+		}
+		return null;
 	}
-	public void setCaseFormat(CaseFormat caseFormat) {
+	public void setCaseFormat(String caseFormat) {
 		this.caseFormat = caseFormat;
 	}
 	public String getConstantPrefix() {
@@ -27,12 +33,13 @@ public class GenerationSetting {
 	}
 	public static GenerationSetting createDefault(CaseFormat format, String prefix, String suffix) {
 		GenerationSetting setting = new GenerationSetting();
-		setting.caseFormat = format;
+		setting.caseFormat = (format != null ? format.name() : null);
 		setting.constantPrefix = prefix;
 		setting.constantSuffix = suffix;
 		return setting;
 		
 	}
+	
 	public GenerationSetting mergeWith(GenerationSetting other) {
 		if ( other == null) {
 			other = new GenerationSetting();

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
@@ -1,7 +1,18 @@
 package com.github.tkurz.sesame.vocab;
 
 import com.google.common.base.CaseFormat;
-
+/**
+ * Simple configuration structure for 
+ * <ul>
+ * <li>caseFormat
+ * <li>constantPrefix
+ * <li>constantSuffix
+ * </ul>
+ * This structure may be used in the <code>pom.xml</code> under
+ * the configuration setting and also with the vocabularies. 
+ * @author dglachs
+ *
+ */
 public class GenerationSetting {
 
 	private CaseFormat caseFormat;
@@ -25,6 +36,13 @@ public class GenerationSetting {
 	public void setConstantSuffix(String constantSuffix) {
 		this.constantSuffix = constantSuffix;
 	}
+	/**
+	 * Helper method for providing a pre-filled setting
+	 * @param format
+	 * @param prefix
+	 * @param suffix
+	 * @return
+	 */
 	public static GenerationSetting createDefault(CaseFormat format, String prefix, String suffix) {
 		GenerationSetting setting = new GenerationSetting();
 		setting.caseFormat = format;
@@ -33,6 +51,13 @@ public class GenerationSetting {
 		return setting;
 		
 	}
+	/**
+	 * Merge another {@link GenerationSetting} with the current one
+	 * if any of the other values is not <code>null</code>, it overrides the actual
+	 * setting. A new instance of {@link GenerationSetting} is created. 
+	 * @param other The other {@link GenerationSetting} object
+	 * @return a new merged {@link GenerationSetting}
+	 */
 	public GenerationSetting mergeWith(GenerationSetting other) {
 		if ( other == null) {
 			other = new GenerationSetting();

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/GenerationSetting.java
@@ -1,0 +1,46 @@
+package com.github.tkurz.sesame.vocab;
+
+import com.google.common.base.CaseFormat;
+
+public class GenerationSetting {
+
+	private CaseFormat caseFormat;
+	private String constantPrefix;
+	private String constantSuffix;
+	public CaseFormat getCaseFormat() {
+		return caseFormat;
+	}
+	public void setCaseFormat(CaseFormat caseFormat) {
+		this.caseFormat = caseFormat;
+	}
+	public String getConstantPrefix() {
+		return constantPrefix;
+	}
+	public void setConstantPrefix(String constantPrefix) {
+		this.constantPrefix = constantPrefix;
+	}
+	public String getConstantSuffix() {
+		return constantSuffix;
+	}
+	public void setConstantSuffix(String constantSuffix) {
+		this.constantSuffix = constantSuffix;
+	}
+	public static GenerationSetting createDefault(CaseFormat format, String prefix, String suffix) {
+		GenerationSetting setting = new GenerationSetting();
+		setting.caseFormat = format;
+		setting.constantPrefix = prefix;
+		setting.constantSuffix = suffix;
+		return setting;
+		
+	}
+	public GenerationSetting mergeWith(GenerationSetting other) {
+		if ( other == null) {
+			other = new GenerationSetting();
+		}
+		GenerationSetting ov = new GenerationSetting();
+		ov.setCaseFormat(other.caseFormat != null ? other.caseFormat : this.caseFormat);
+		ov.setConstantPrefix(other.constantPrefix != null ? other.constantPrefix : this.constantPrefix);
+		ov.setConstantSuffix(other.constantSuffix != null ? other.constantSuffix : this.constantSuffix);
+		return ov;
+	}
+}

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
@@ -381,7 +381,7 @@ public class VocabBuilder {
 
     public HashMap<String, Properties> generateResourceBundle(String baseName) throws GenerationException {
     	// be sure to have at least the default URI constant settings
-    	if ( uriGeneration == null && stringGeneration == null ) {
+    	if ( uriGeneration == null ) {
     		uriGeneration = GenerationSetting.createDefault(caseFormat, "", "");
     	}
         Pattern pattern = Pattern.compile(Pattern.quote(getPrefix()) + "(.+)");

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
@@ -51,11 +51,13 @@ public class VocabBuilder {
     private String language = null;
     private final Model model;
     private CaseFormat caseFormat = null;
-    private CaseFormat stringCaseFormat = null;
-    private String stringPropertyPrefix, stringPropertySuffix;
+//    private CaseFormat stringCaseFormat = null;
+//    private String stringPropertyPrefix, stringPropertySuffix;
     private Set<String> createdFields = new HashSet<>();
     private static Set<String> reservedWords = Sets.newHashSet("abstract","assert","boolean","break","byte","case","catch","char","class","const","default","do","double","else","enum","extends","false","final","finally","float","for","goto","if","implements","import","instanceof","int","interface","long","native","new","null","package","private","protected","public","return","short","static","strictfp","super","switch","synchronized","this","throw","throws","transient","true","try","void","volatile","while","continue","PREFIX","NAMESPACE");
 
+    private GenerationSetting stringGeneration;
+    private GenerationSetting uriGeneration;
     /**
      * Create a new VocabularyBuilder, reading the vocab definition from the provided file
      *
@@ -111,6 +113,11 @@ public class VocabBuilder {
      *
      */
     public void generate(String className, PrintWriter out) throws IOException, GraphUtilException, GenerationException {
+    	// be sure to have at least the uri constants generated
+    	if ( stringGeneration == null && uriGeneration == null ) {
+    		uriGeneration = GenerationSetting.createDefault(caseFormat, "", "");
+            //throw new GenerationException("no generation settings present, please set explicitly");
+    	}
         log.trace("classname: {}", className);
         if (StringUtils.isBlank(name)) {
             name = className;
@@ -190,73 +197,150 @@ public class VocabBuilder {
         List<String> keys = new ArrayList<>();
         keys.addAll(splitUris.keySet());
         Collections.sort(keys, String.CASE_INSENSITIVE_ORDER);
+        // do the string constant generation (if set)
+		if (stringGeneration != null) {
+			for (String key : keys) {
+				final Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(),
+						COMMENT_PROPERTIES);
+				final Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(),
+						LABEL_PROPERTIES);
 
+				out.println(getIndent(1) + "/**");
+				if (label != null) {
+					out.printf(getIndent(1) + " * %s%n", label.getLabel());
+					out.println(getIndent(1) + " * <p>");
+				}
+				out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
+				if (comment != null) {
+					out.println(getIndent(1) + " * <p>");
+					out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70,
+							"\n" + getIndent(1) + " * ", false));
+				}
+				out.println(getIndent(1) + " *");
+				out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
+				out.println(getIndent(1) + " */");
+
+				final String nextKey = cleanKey(
+						String.format("%s%s%s", StringUtils.defaultString(stringGeneration.getConstantPrefix()),
+								doCaseFormatting(key, stringGeneration.getCaseFormat()),
+								StringUtils.defaultString(stringGeneration.getConstantSuffix())));
+				checkField(className, nextKey);
+				out.printf(getIndent(1) + "public static final String %s = %s.NAMESPACE + \"%s\";%n", nextKey,
+						className, key);
+				out.println();
+			}
+
+        }
+		// do the entire uri constant generation
+		if ( uriGeneration != null ) {
+	        for (String key : keys) {
+	            Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
+	            Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
+
+	            out.println(getIndent(1) + "/**");
+	            if (label != null) {
+	                out.printf(getIndent(1) + " * %s%n", label.getLabel());
+	                out.println(getIndent(1) + " * <p>");
+	            }
+	            out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
+	            if (comment != null) {
+	                out.println(getIndent(1) + " * <p>");
+	                out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
+	            }
+	            out.println(getIndent(1) + " *");
+	            out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
+	            out.println(getIndent(1) + " */");
+				final String nextKey = cleanKey(
+						String.format("%s%s%s", StringUtils.defaultString(uriGeneration.getConstantPrefix()),
+								doCaseFormatting(key, uriGeneration.getCaseFormat()),
+								StringUtils.defaultString(uriGeneration.getConstantSuffix())));
+
+	            //String nextKey = cleanKey(doCaseFormatting(key, uriGeneration.getCaseFormat()));
+	            checkField(className, nextKey);
+	            out.printf(getIndent(1) + "public static final URI %s;%n", nextKey);
+	            out.println();
+	        }
+	        //static init
+	        out.println(getIndent(1) + "static {");
+	        out.printf(getIndent(2) + "ValueFactory factory = ValueFactoryImpl.getInstance();%n");
+	        out.println();
+	        for (String key : keys) {
+				final String nextKey = cleanKey(
+						String.format("%s%s%s", StringUtils.defaultString(uriGeneration.getConstantPrefix()),
+								doCaseFormatting(key, uriGeneration.getCaseFormat()),
+								StringUtils.defaultString(uriGeneration.getConstantSuffix())));
+	            out.printf(getIndent(2) + "%s = factory.createURI(%s.NAMESPACE, \"%s\");%n", nextKey, className, key);
+	        }
+	        out.println(getIndent(1) + "}");
+	        out.println();
+
+		}
         //string constant values
-        if (stringCaseFormat != null || StringUtils.isNotBlank(stringPropertyPrefix) || (StringUtils.isNotBlank(stringPropertySuffix))) {
-            // add the possibility to add a string property with the namespace for usage in
-            for (String key : keys) {
-                final Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
-                final Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
+//        if (stringCaseFormat != null || StringUtils.isNotBlank(stringPropertyPrefix) || (StringUtils.isNotBlank(stringPropertySuffix))) {
+//            // add the possibility to add a string property with the namespace for usage in
+//            for (String key : keys) {
+//                final Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
+//                final Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
+//
+//                out.println(getIndent(1) + "/**");
+//                if (label != null) {
+//                    out.printf(getIndent(1) + " * %s%n", label.getLabel());
+//                    out.println(getIndent(1) + " * <p>");
+//                }
+//                out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
+//                if (comment != null) {
+//                    out.println(getIndent(1) + " * <p>");
+//                    out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
+//                }
+//                out.println(getIndent(1) + " *");
+//                out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
+//                out.println(getIndent(1) + " */");
+//
+//                final String nextKey = cleanKey(String.format("%s%s%s", StringUtils.defaultString(getStringPropertyPrefix()),
+//                        doCaseFormatting(key, getStringConstantCase()),
+//                        StringUtils.defaultString(getStringPropertySuffix())));
+//                checkField(className, nextKey);
+//                out.printf(getIndent(1) + "public static final String %s = %s.NAMESPACE + \"%s\";%n",
+//                         nextKey, className, key);
+//                out.println();
+//            }
+//        }
+//
+//        //and now the resources
+//        for (String key : keys) {
+//            Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
+//            Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
+//
+//            out.println(getIndent(1) + "/**");
+//            if (label != null) {
+//                out.printf(getIndent(1) + " * %s%n", label.getLabel());
+//                out.println(getIndent(1) + " * <p>");
+//            }
+//            out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
+//            if (comment != null) {
+//                out.println(getIndent(1) + " * <p>");
+//                out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
+//            }
+//            out.println(getIndent(1) + " *");
+//            out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
+//            out.println(getIndent(1) + " */");
+//
+//            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
+//            checkField(className, nextKey);
+//            out.printf(getIndent(1) + "public static final URI %s;%n", nextKey);
+//            out.println();
+//        }
 
-                out.println(getIndent(1) + "/**");
-                if (label != null) {
-                    out.printf(getIndent(1) + " * %s%n", label.getLabel());
-                    out.println(getIndent(1) + " * <p>");
-                }
-                out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
-                if (comment != null) {
-                    out.println(getIndent(1) + " * <p>");
-                    out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
-                }
-                out.println(getIndent(1) + " *");
-                out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
-                out.println(getIndent(1) + " */");
-
-                final String nextKey = cleanKey(String.format("%s%s%s", StringUtils.defaultString(getStringPropertyPrefix()),
-                        doCaseFormatting(key, getStringConstantCase()),
-                        StringUtils.defaultString(getStringPropertySuffix())));
-                checkField(className, nextKey);
-                out.printf(getIndent(1) + "public static final String %s = %s.NAMESPACE + \"%s\";%n",
-                         nextKey, className, key);
-                out.println();
-            }
-        }
-
-        //and now the resources
-        for (String key : keys) {
-            Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
-            Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
-
-            out.println(getIndent(1) + "/**");
-            if (label != null) {
-                out.printf(getIndent(1) + " * %s%n", label.getLabel());
-                out.println(getIndent(1) + " * <p>");
-            }
-            out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
-            if (comment != null) {
-                out.println(getIndent(1) + " * <p>");
-                out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
-            }
-            out.println(getIndent(1) + " *");
-            out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
-            out.println(getIndent(1) + " */");
-
-            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
-            checkField(className, nextKey);
-            out.printf(getIndent(1) + "public static final URI %s;%n", nextKey);
-            out.println();
-        }
-
-        //static init
-        out.println(getIndent(1) + "static {");
-        out.printf(getIndent(2) + "ValueFactory factory = ValueFactoryImpl.getInstance();%n");
-        out.println();
-        for (String key : keys) {
-            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
-            out.printf(getIndent(2) + "%s = factory.createURI(%s.NAMESPACE, \"%s\");%n", nextKey, className, key);
-        }
-        out.println(getIndent(1) + "}");
-        out.println();
+//        //static init
+//        out.println(getIndent(1) + "static {");
+//        out.printf(getIndent(2) + "ValueFactory factory = ValueFactoryImpl.getInstance();%n");
+//        out.println();
+//        for (String key : keys) {
+//            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
+//            out.printf(getIndent(2) + "%s = factory.createURI(%s.NAMESPACE, \"%s\");%n", nextKey, className, key);
+//        }
+//        out.println(getIndent(1) + "}");
+//        out.println();
 
         //private contructor to avoid instances
         out.printf(getIndent(1) + "private %s() {%n", className);
@@ -296,6 +380,10 @@ public class VocabBuilder {
     }
 
     public HashMap<String, Properties> generateResourceBundle(String baseName) throws GenerationException {
+    	// be sure to have at least the default URI constant settings
+    	if ( uriGeneration == null && stringGeneration == null ) {
+    		uriGeneration = GenerationSetting.createDefault(caseFormat, "", "");
+    	}
         Pattern pattern = Pattern.compile(Pattern.quote(getPrefix()) + "(.+)");
         HashMap<String, URI> splitUris = new HashMap<>();
         for (Resource nextSubject : model.subjects()) {
@@ -317,7 +405,8 @@ public class VocabBuilder {
         bundles.put(baseName, new Properties());
         for (String key : keys) {
             final URI resource = splitUris.get(key);
-            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
+            // 
+            String nextKey = cleanKey(doCaseFormatting(key, uriGeneration.getCaseFormat()));
 
             for (URI p : LABEL_PROPERTIES) {
                 for (Value v : GraphUtil.getObjects(model, resource, p)) {
@@ -485,34 +574,51 @@ public class VocabBuilder {
     }
 
     public void setConstantCase(CaseFormat caseFormat) {
-        this.caseFormat = caseFormat;
+    	this.caseFormat = caseFormat;
     }
 
     public CaseFormat getConstantCase() {
         return caseFormat;
     }
+//
+//    public CaseFormat getStringConstantCase() {
+//        return stringCaseFormat;
+//    }
+//
+//    public void setStringConstantCase(CaseFormat stringCaseFormat) {
+//        this.stringCaseFormat = stringCaseFormat;
+//    }
+//
+//    public String getStringPropertyPrefix() {
+//        return stringPropertyPrefix;
+//    }
+//
+//    public void setStringPropertyPrefix(String stringPropertyPrefix) {
+//    	
+//        this.stringPropertyPrefix = stringPropertyPrefix;
+//    }
+//
+//    public String getStringPropertySuffix() {
+//		return stringPropertySuffix;
+//	}
+//
+//	public void setStringPropertySuffix(String stringPropertySuffix) {
+//		this.stringPropertySuffix = stringPropertySuffix;
+//	}
 
-    public CaseFormat getStringConstantCase() {
-        return stringCaseFormat;
-    }
-
-    public void setStringConstantCase(CaseFormat stringCaseFormat) {
-        this.stringCaseFormat = stringCaseFormat;
-    }
-
-    public String getStringPropertyPrefix() {
-        return stringPropertyPrefix;
-    }
-
-    public void setStringPropertyPrefix(String stringPropertyPrefix) {
-        this.stringPropertyPrefix = stringPropertyPrefix;
-    }
-
-    public String getStringPropertySuffix() {
-		return stringPropertySuffix;
+	public GenerationSetting getStringGeneration() {
+		return stringGeneration;
 	}
 
-	public void setStringPropertySuffix(String stringPropertySuffix) {
-		this.stringPropertySuffix = stringPropertySuffix;
+	public void setStringGeneration(GenerationSetting stringGeneration) {
+		this.stringGeneration = stringGeneration;
+	}
+
+	public GenerationSetting getUriGeneration() {
+		return uriGeneration;
+	}
+
+	public void setUriGeneration(GenerationSetting uriGeneration) {
+		this.uriGeneration = uriGeneration;
 	}
 }

--- a/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
+++ b/vocab-builder-core/src/main/java/com/github/tkurz/sesame/vocab/VocabBuilder.java
@@ -221,6 +221,7 @@ public class VocabBuilder {
 				out.println(getIndent(1) + " */");
 
 				final String nextKey = cleanKey(
+						// NOTE: CONSTANT PREFIX and constant SUFFIX are NOT part of caseFormatting
 						String.format("%s%s%s", StringUtils.defaultString(stringGeneration.getConstantPrefix()),
 								doCaseFormatting(key, stringGeneration.getCaseFormat()),
 								StringUtils.defaultString(stringGeneration.getConstantSuffix())));
@@ -251,6 +252,7 @@ public class VocabBuilder {
 	            out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
 	            out.println(getIndent(1) + " */");
 				final String nextKey = cleanKey(
+						// NOTE: CONSTANT PREFIX and constant SUFFIX are NOT part of caseFormatting
 						String.format("%s%s%s", StringUtils.defaultString(uriGeneration.getConstantPrefix()),
 								doCaseFormatting(key, uriGeneration.getCaseFormat()),
 								StringUtils.defaultString(uriGeneration.getConstantSuffix())));
@@ -266,6 +268,7 @@ public class VocabBuilder {
 	        out.println();
 	        for (String key : keys) {
 				final String nextKey = cleanKey(
+						// NOTE: CONSTANT PREFIX and constant SUFFIX are NOT part of caseFormatting
 						String.format("%s%s%s", StringUtils.defaultString(uriGeneration.getConstantPrefix()),
 								doCaseFormatting(key, uriGeneration.getCaseFormat()),
 								StringUtils.defaultString(uriGeneration.getConstantSuffix())));
@@ -275,72 +278,6 @@ public class VocabBuilder {
 	        out.println();
 
 		}
-        //string constant values
-//        if (stringCaseFormat != null || StringUtils.isNotBlank(stringPropertyPrefix) || (StringUtils.isNotBlank(stringPropertySuffix))) {
-//            // add the possibility to add a string property with the namespace for usage in
-//            for (String key : keys) {
-//                final Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
-//                final Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
-//
-//                out.println(getIndent(1) + "/**");
-//                if (label != null) {
-//                    out.printf(getIndent(1) + " * %s%n", label.getLabel());
-//                    out.println(getIndent(1) + " * <p>");
-//                }
-//                out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
-//                if (comment != null) {
-//                    out.println(getIndent(1) + " * <p>");
-//                    out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
-//                }
-//                out.println(getIndent(1) + " *");
-//                out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
-//                out.println(getIndent(1) + " */");
-//
-//                final String nextKey = cleanKey(String.format("%s%s%s", StringUtils.defaultString(getStringPropertyPrefix()),
-//                        doCaseFormatting(key, getStringConstantCase()),
-//                        StringUtils.defaultString(getStringPropertySuffix())));
-//                checkField(className, nextKey);
-//                out.printf(getIndent(1) + "public static final String %s = %s.NAMESPACE + \"%s\";%n",
-//                         nextKey, className, key);
-//                out.println();
-//            }
-//        }
-//
-//        //and now the resources
-//        for (String key : keys) {
-//            Literal comment = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), COMMENT_PROPERTIES);
-//            Literal label = getFirstExistingObjectLiteral(model, splitUris.get(key), getPreferredLanguage(), LABEL_PROPERTIES);
-//
-//            out.println(getIndent(1) + "/**");
-//            if (label != null) {
-//                out.printf(getIndent(1) + " * %s%n", label.getLabel());
-//                out.println(getIndent(1) + " * <p>");
-//            }
-//            out.printf(getIndent(1) + " * {@code %s}.%n", splitUris.get(key).stringValue());
-//            if (comment != null) {
-//                out.println(getIndent(1) + " * <p>");
-//                out.printf(getIndent(1) + " * %s%n", WordUtils.wrap(comment.getLabel().replaceAll("\\s+", " "), 70, "\n" + getIndent(1) + " * ", false));
-//            }
-//            out.println(getIndent(1) + " *");
-//            out.printf(getIndent(1) + " * @see <a href=\"%s\">%s</a>%n", splitUris.get(key), key);
-//            out.println(getIndent(1) + " */");
-//
-//            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
-//            checkField(className, nextKey);
-//            out.printf(getIndent(1) + "public static final URI %s;%n", nextKey);
-//            out.println();
-//        }
-
-//        //static init
-//        out.println(getIndent(1) + "static {");
-//        out.printf(getIndent(2) + "ValueFactory factory = ValueFactoryImpl.getInstance();%n");
-//        out.println();
-//        for (String key : keys) {
-//            String nextKey = cleanKey(doCaseFormatting(key, getConstantCase()));
-//            out.printf(getIndent(2) + "%s = factory.createURI(%s.NAMESPACE, \"%s\");%n", nextKey, className, key);
-//        }
-//        out.println(getIndent(1) + "}");
-//        out.println();
 
         //private contructor to avoid instances
         out.printf(getIndent(1) + "private %s() {%n", className);

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/Vocabulary.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/Vocabulary.java
@@ -3,6 +3,7 @@ package com.github.tkurz.sesame.vocab.plugin;
 import java.io.File;
 import java.net.URL;
 
+import com.github.tkurz.sesame.vocab.GenerationSetting;
 import com.google.common.base.CaseFormat;
 
 /**
@@ -26,6 +27,14 @@ public class Vocabulary {
     private Boolean createResourceBundles;
     private CaseFormat caseFormat;
     private String prefix;
+    /**
+     * Allow vocabulary specific override
+     */
+    private GenerationSetting uriGeneration;
+    /**
+     * Allow vocabulary specific override
+     */
+    private GenerationSetting stringGeneration;
 
     public URL getUrl() {
         return url;
@@ -96,6 +105,10 @@ public class Vocabulary {
     }
 
     public CaseFormat getConstantCase() {
+    	// 
+    	if ( uriGeneration != null && uriGeneration.getCaseFormat() != null ) {
+    		return uriGeneration.getCaseFormat();
+    	}
         return caseFormat;
     }
 
@@ -126,4 +139,20 @@ public class Vocabulary {
     public void setCreateResourceBundles(boolean createResourceBundles) {
         this.createResourceBundles = createResourceBundles;
     }
+
+	public GenerationSetting getUriGeneration() {
+		return uriGeneration;
+	}
+
+	public void setUriGeneration(GenerationSetting uriGeneration) {
+		this.uriGeneration = uriGeneration;
+	}
+
+	public GenerationSetting getStringGeneration() {
+		return stringGeneration;
+	}
+
+	public void setStringGeneration(GenerationSetting stringGeneration) {
+		this.stringGeneration = stringGeneration;
+	}
 }

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -95,7 +95,7 @@ public class VocabularyBuilderMojo extends AbstractMojo {
     @Parameter(property = "constantCase")
     private CaseFormat constantCase;
 
-    @Parameter(property = "stringConstantCase", defaultValue = "UPPER_UNDERSCORE")
+    @Parameter(property = "stringConstantCase") //, defaultValue = "UPPER_UNDERSCORE")
     private CaseFormat stringConstantCase;
 
     @Parameter(property = "project", required = true, readonly = true)

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -52,8 +52,6 @@ import java.util.*;
         requiresDependencyResolution = ResolutionScope.COMPILE,
         requiresProject = true)
 public class VocabularyBuilderMojo extends AbstractMojo {
-
-	
     @Parameter(property = "output", defaultValue = "${project.build.directory}/generated-sources/sesame-vocabs")
     private File outputDirectory;
 
@@ -107,15 +105,10 @@ public class VocabularyBuilderMojo extends AbstractMojo {
      * Specify whether to generate the URI constant section, 
      * defaults to <code>true</code>
      */
-    @Deprecated // when removing the @Parameter - change this to a static final Boolean 
     @Parameter(property = "createUriConstants", defaultValue = "true")
     private boolean createUriConstants;
-
-    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantPrefix", defaultValue = "")
     private String uriConstantPrefix;
-
-    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantSuffix", defaultValue = "")
     private String uriConstantSuffix;
 
@@ -123,27 +116,17 @@ public class VocabularyBuilderMojo extends AbstractMojo {
      * Specify whether to generate the String constant section , 
      * defaults to <code>true</code>
      */
-   
-    @Deprecated // when removing the @Parameter - change this to a static final Boolean 
     @Parameter(property = "createStringConstants", defaultValue = "true")
     private boolean createStringConstants;
-
-    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantPrefix", defaultValue = "")
     private String stringConstantPrefix;
-
-    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantSuffix", defaultValue = "_STRING")
     private String stringConstantSuffix;
     /**
      * Specify the case adjustment (if any) for all generated sections 
      * (URI constants, Strings) and resource bundle
      */
-    @Parameter(property = "constantCase", defaultValue="NONE")
-    private String constantCaseStr;
-    /**
-     * the constant case for adjusting the case format (if not "NONE")
-     */
+    @Parameter(property = "constantCase")
     private CaseFormat constantCase;
     
     // not used - left because of existing pom.xml
@@ -187,12 +170,10 @@ public class VocabularyBuilderMojo extends AbstractMojo {
             final Log log = getLog();
             log.info(String.format("Generating %d vocabularies", vocabularies.size()));
 
-            // String is either NONE (=default) or the constants from CaseFormat
-            // if not valid, no formatting applies
-            constantCase = caseFormatFromString(constantCaseStr);
+
             // be sure to generate at least the uri's if no configuration is present
             if ( createUriConstants && uriGeneration == null  ) {
-            	// when no setting for uri generation present - create new default setting based
+            	// when no setting for uri generation present - create new default setting 
             	uriGeneration = GenerationSetting.createDefault(constantCase, uriConstantPrefix, uriConstantSuffix);
             }
             if ( createStringConstants && stringGeneration == null ) {
@@ -412,19 +393,6 @@ public class VocabularyBuilderMojo extends AbstractMojo {
         } catch (IOException e) {
             throw new MojoExecutionException("Could not write Vocabularies", e);
         }
-    }
-    /**
-     * Helper method for initializing based on the provided caseFormat string 
-     * @param caseFormat
-     * @return
-     */
-    private CaseFormat caseFormatFromString(String caseFormat) {
-    	try {
-    		return CaseFormat.valueOf(caseFormat);
-    	} catch (Exception e) {
-    		// null will be treated as NONE
-    		return null;
-    	}
     }
 
     private File fetchVocab(URL url, final String displayName, final Vocabulary vocab) throws URISyntaxException, IOException {

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -297,14 +297,14 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                     /*
                      * createUriConstants, createStringConstants may be set to false by the user 
                      */
-                    if ( createUriConstants && uriGeneration != null ) {
+                    if (createUriConstants && uriGeneration != null) {
                     	/*
                     	 * when uri constant generation, use default generation settings and override
                     	 * with vocabulary specific settings (if present)
                     	 */
                     	builder.setUriGeneration(uriGeneration.mergeWith(vocab.getUriGeneration()));
                     }
-                    else if ( vocab.getUriGeneration() != null ) {
+                    else if (vocab.getUriGeneration() != null) {
                     	/*
                     	 * when uri constant generation deactivated, vocabulary specific settings
                     	 * may apply 
@@ -312,7 +312,7 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                     	builder.setUriGeneration(vocab.getUriGeneration());
                     }
                     // when string constant generation set, specify prefix and suffix
-                    if ( createStringConstants && stringGeneration != null ) {
+                    if (createStringConstants && stringGeneration != null) {
                     	/*
                     	 * when string constant generation, use default generation settings and override
                     	 * with vocabulary specific settings (if present)
@@ -326,21 +326,6 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                     	 */
                     	builder.setStringGeneration(vocab.getStringGeneration());
                     }
-//                    if ( uriGeneration != null ) {
-//                    	builder.setUriGeneration(uriGeneration);
-//                    }
-//                    if (createStringConstants) {
-//                        // when prefix set, the builder will generate string constants in addition to the URI's
-//                        // when no string constant prefix set, use a single underscore by default
-//                        builder.setStringPropertyPrefix(stringConstantPrefix);
-//                        builder.setStringPropertySuffix(stringConstantSuffix);
-//                        builder.setStringConstantCase(stringConstantCase);
-//                    } else {
-//                        // be sure to not generate String constants
-//                        builder.setStringPropertyPrefix(null);
-//                        builder.setStringPropertySuffix(null);
-//                        builder.setStringConstantCase(null);
-//                    }
                     final Path vFile = target.resolve(fName);
                     final String className = vFile.getFileName().toString().replaceFirst("\\.java$", "");
                     try (final PrintWriter out = new PrintWriter(

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -1,6 +1,7 @@
 package com.github.tkurz.sesame.vocab.plugin;
 
 import com.github.tkurz.sesame.vocab.GenerationException;
+import com.github.tkurz.sesame.vocab.GenerationSetting;
 import com.github.tkurz.sesame.vocab.VocabBuilder;
 import com.google.common.base.CaseFormat;
 
@@ -51,7 +52,6 @@ import java.util.*;
         requiresDependencyResolution = ResolutionScope.COMPILE,
         requiresProject = true)
 public class VocabularyBuilderMojo extends AbstractMojo {
-
     @Parameter(property = "output", defaultValue = "${project.build.directory}/generated-sources/sesame-vocabs")
     private File outputDirectory;
 
@@ -60,10 +60,24 @@ public class VocabularyBuilderMojo extends AbstractMojo {
 
     @Parameter(property = "remoteCacheDir", defaultValue = "${project.build.directory}/vocab-builder-maven-plugin.cache")
     private File remoteCacheDir;
-
+    /**
+     * Prefix & Suffix settings for URI constant generation
+     * if not present, the default values apply
+     */
+    @Parameter(property = "uriGeneration")
+    private GenerationSetting uriGeneration;
+    /**
+     * Prefix & Suffix settings for String constant generation
+     * if not present, the default values apply
+     */
+    @Parameter(property = "stringGeneration")
+    private GenerationSetting stringGeneration;
+    /**
+     * The list of vocabularies to process
+     */
     @Parameter
     private List<Vocabulary> vocabularies;
-
+    
     @Parameter(property = "url")
     private URL url;
     @Parameter(property = "file")
@@ -81,22 +95,43 @@ public class VocabularyBuilderMojo extends AbstractMojo {
 
     @Parameter(property = "preferredLanguage")
     private String preferredLanguage;
-
+    /**
+     * Specify whether to generate a resource bundle, 
+     * defaults to <code>false</code>
+     */
     @Parameter(property = "createResourceBundles", defaultValue = "false")
     private boolean createResourceBundles;
+    /**
+     * Specify whether to generate the URI constant section, 
+     * defaults to <code>true</code>
+     */
+    @Parameter(property = "createUriConstants", defaultValue = "true")
+    private boolean createUriConstants;
+    @Parameter(property = "stringConstantPrefix", defaultValue = "")
+    private String uriConstantPrefix;
+    @Parameter(property = "stringConstantSuffix", defaultValue = "")
+    private String uriConstantSuffix;
 
+    /**
+     * Specify whether to generate the String constant section , 
+     * defaults to <code>true</code>
+     */
     @Parameter(property = "createStringConstants", defaultValue = "true")
     private boolean createStringConstants;
     @Parameter(property = "stringConstantPrefix", defaultValue = "")
     private String stringConstantPrefix;
     @Parameter(property = "stringConstantSuffix", defaultValue = "_STRING")
     private String stringConstantSuffix;
-
+    /**
+     * Specify the case adjustment (if any) for all generated sections 
+     * (URI constants, Strings) and resource bundle
+     */
     @Parameter(property = "constantCase")
     private CaseFormat constantCase;
-
-    @Parameter(property = "stringConstantCase") //, defaultValue = "UPPER_UNDERSCORE")
-    private CaseFormat stringConstantCase;
+    
+//
+//    @Parameter(property = "stringConstantCase") //, defaultValue = "UPPER_UNDERSCORE")
+//    private CaseFormat stringConstantCase;
 
     @Parameter(property = "project", required = true, readonly = true)
     private MavenProject project;
@@ -135,6 +170,20 @@ public class VocabularyBuilderMojo extends AbstractMojo {
             final Log log = getLog();
             log.info(String.format("Generating %d vocabularies", vocabularies.size()));
 
+
+            // be sure to generate at least the uri's if no configuration is present
+            if ( createUriConstants && uriGeneration == null  ) {
+            	// when no setting for uri generation present - create new default setting 
+            	uriGeneration = GenerationSetting.createDefault(constantCase, uriConstantPrefix, uriConstantSuffix);
+            }
+            if ( createStringConstants && stringGeneration == null ) {
+            	// when no setting for string generation present - create new default setting 
+            	stringGeneration = GenerationSetting.createDefault(constantCase, stringConstantPrefix, stringConstantSuffix);
+            }
+            if ( stringGeneration == null && uriGeneration == null ) {
+            	// be sure to generate at least the URI's
+            	uriGeneration = GenerationSetting.createDefault(constantCase, uriConstantPrefix, uriConstantSuffix);
+            }
             for (Vocabulary vocab : vocabularies) {
                 final String displayName = vocab.getName() != null ? vocab.getName() : vocab.getClassName();
                 if (displayName == null) {
@@ -245,19 +294,50 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                         target = target.resolve(builder.getPackageName().replaceAll("\\.", "/"));
                         Files.createDirectories(target);
                     }
-                    // when string constant generation set, specify prefix and suffix
-                    if (createStringConstants) {
-                        // when prefix set, the builder will generate string constants in addition to the URI's
-                        // when no string constant prefix set, use a single underscore by default
-                        builder.setStringPropertyPrefix(stringConstantPrefix);
-                        builder.setStringPropertySuffix(stringConstantSuffix);
-                        builder.setStringConstantCase(stringConstantCase);
-                    } else {
-                        // be sure to not generate String constants
-                        builder.setStringPropertyPrefix(null);
-                        builder.setStringPropertySuffix(null);
-                        builder.setStringConstantCase(null);
+                    if ( createUriConstants && uriGeneration != null ) {
+                    	/*
+                    	 * when uri constant generation, use default generation settings and override
+                    	 * with vocabulary specific settings (if present)
+                    	 */
+                    	builder.setUriGeneration(uriGeneration.mergeWith(vocab.getUriGeneration()));
                     }
+                    else if ( vocab.getUriGeneration() != null ) {
+                    	/*
+                    	 * when uri constant generation deactivated, vocabulary specific settings
+                    	 * may apply 
+                    	 */
+                    	builder.setUriGeneration(vocab.getUriGeneration());
+                    }
+                    // when string constant generation set, specify prefix and suffix
+                    if ( createStringConstants && stringGeneration != null ) {
+                    	/*
+                    	 * when string constant generation, use default generation settings and override
+                    	 * with vocabulary specific settings (if present)
+                    	 */
+                    	builder.setStringGeneration(stringGeneration.mergeWith(vocab.getStringGeneration()));
+                    }
+                    else if (vocab.getStringGeneration() != null ) { 
+                    	/*
+                    	 * when string constant generation deactivated, vocabulary specific settings
+                    	 * may apply 
+                    	 */
+                    	builder.setStringGeneration(vocab.getStringGeneration());
+                    }
+//                    if ( uriGeneration != null ) {
+//                    	builder.setUriGeneration(uriGeneration);
+//                    }
+//                    if (createStringConstants) {
+//                        // when prefix set, the builder will generate string constants in addition to the URI's
+//                        // when no string constant prefix set, use a single underscore by default
+//                        builder.setStringPropertyPrefix(stringConstantPrefix);
+//                        builder.setStringPropertySuffix(stringConstantSuffix);
+//                        builder.setStringConstantCase(stringConstantCase);
+//                    } else {
+//                        // be sure to not generate String constants
+//                        builder.setStringPropertyPrefix(null);
+//                        builder.setStringPropertySuffix(null);
+//                        builder.setStringConstantCase(null);
+//                    }
                     final Path vFile = target.resolve(fName);
                     final String className = vFile.getFileName().toString().replaceFirst("\\.java$", "");
                     try (final PrintWriter out = new PrintWriter(

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -129,9 +129,9 @@ public class VocabularyBuilderMojo extends AbstractMojo {
     @Parameter(property = "constantCase")
     private CaseFormat constantCase;
     
-//
-//    @Parameter(property = "stringConstantCase") //, defaultValue = "UPPER_UNDERSCORE")
-//    private CaseFormat stringConstantCase;
+    // not used - left because of existing pom.xml
+    @Parameter(property = "stringConstantCase") //, defaultValue = "UPPER_UNDERSCORE")
+    private CaseFormat stringConstantCase;
 
     @Parameter(property = "project", required = true, readonly = true)
     private MavenProject project;

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -52,6 +52,8 @@ import java.util.*;
         requiresDependencyResolution = ResolutionScope.COMPILE,
         requiresProject = true)
 public class VocabularyBuilderMojo extends AbstractMojo {
+
+	
     @Parameter(property = "output", defaultValue = "${project.build.directory}/generated-sources/sesame-vocabs")
     private File outputDirectory;
 
@@ -105,10 +107,15 @@ public class VocabularyBuilderMojo extends AbstractMojo {
      * Specify whether to generate the URI constant section, 
      * defaults to <code>true</code>
      */
+    @Deprecated // when removing the @Parameter - change this to a static final Boolean 
     @Parameter(property = "createUriConstants", defaultValue = "true")
     private boolean createUriConstants;
+
+    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantPrefix", defaultValue = "")
     private String uriConstantPrefix;
+
+    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantSuffix", defaultValue = "")
     private String uriConstantSuffix;
 
@@ -116,17 +123,27 @@ public class VocabularyBuilderMojo extends AbstractMojo {
      * Specify whether to generate the String constant section , 
      * defaults to <code>true</code>
      */
+   
+    @Deprecated // when removing the @Parameter - change this to a static final Boolean 
     @Parameter(property = "createStringConstants", defaultValue = "true")
     private boolean createStringConstants;
+
+    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantPrefix", defaultValue = "")
     private String stringConstantPrefix;
+
+    @Deprecated // when removing the @Parameter - change this to a static final String 
     @Parameter(property = "stringConstantSuffix", defaultValue = "_STRING")
     private String stringConstantSuffix;
     /**
      * Specify the case adjustment (if any) for all generated sections 
      * (URI constants, Strings) and resource bundle
      */
-    @Parameter(property = "constantCase")
+    @Parameter(property = "constantCase", defaultValue="NONE")
+    private String constantCaseStr;
+    /**
+     * the constant case for adjusting the case format (if not "NONE")
+     */
     private CaseFormat constantCase;
     
     // not used - left because of existing pom.xml
@@ -170,10 +187,12 @@ public class VocabularyBuilderMojo extends AbstractMojo {
             final Log log = getLog();
             log.info(String.format("Generating %d vocabularies", vocabularies.size()));
 
-
+            // String is either NONE (=default) or the constants from CaseFormat
+            // if not valid, no formatting applies
+            constantCase = caseFormatFromString(constantCaseStr);
             // be sure to generate at least the uri's if no configuration is present
             if ( createUriConstants && uriGeneration == null  ) {
-            	// when no setting for uri generation present - create new default setting 
+            	// when no setting for uri generation present - create new default setting based
             	uriGeneration = GenerationSetting.createDefault(constantCase, uriConstantPrefix, uriConstantSuffix);
             }
             if ( createStringConstants && stringGeneration == null ) {
@@ -393,6 +412,19 @@ public class VocabularyBuilderMojo extends AbstractMojo {
         } catch (IOException e) {
             throw new MojoExecutionException("Could not write Vocabularies", e);
         }
+    }
+    /**
+     * Helper method for initializing based on the provided caseFormat string 
+     * @param caseFormat
+     * @return
+     */
+    private CaseFormat caseFormatFromString(String caseFormat) {
+    	try {
+    		return CaseFormat.valueOf(caseFormat);
+    	} catch (Exception e) {
+    		// null will be treated as NONE
+    		return null;
+    	}
     }
 
     private File fetchVocab(URL url, final String displayName, final Vocabulary vocab) throws URISyntaxException, IOException {

--- a/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
+++ b/vocab-builder-maven-plugin/src/main/java/com/github/tkurz/sesame/vocab/plugin/VocabularyBuilderMojo.java
@@ -294,6 +294,9 @@ public class VocabularyBuilderMojo extends AbstractMojo {
                         target = target.resolve(builder.getPackageName().replaceAll("\\.", "/"));
                         Files.createDirectories(target);
                     }
+                    /*
+                     * createUriConstants, createStringConstants may be set to false by the user 
+                     */
                     if ( createUriConstants && uriGeneration != null ) {
                     	/*
                     	 * when uri constant generation, use default generation settings and override


### PR DESCRIPTION
this solves the following problem:

when having similar names for attributes and classes, such as
- ssn:FeatureOfInterest (denoting a class)
- ssn:featureOfInterest (denoting a property)

having UPPER_UNDERSCORE as the default stringConstantCase will cause duplicate fields ...and there is no possibility to omit reformatting to any of the CaseFormat options. 
