### PR TITLE
Conversion from Sesame to RDF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
     </scm>
 
     <properties>
-        <jackson.version>2.3.3</jackson.version>
+        <jackson.version>2.6.3</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <sesame.version>2.7.11</sesame.version>
-        <slf4j.version>1.7.7</slf4j.version>
+        <rdf4j.version>2.0M3</rdf4j.version>
+        <slf4j.version>1.7.21</slf4j.version>
     </properties>
 
     <prerequisites>
@@ -66,10 +66,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.5.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -116,14 +116,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-model</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-model</artifactId>
+                <version>${rdf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-api</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-api</artifactId>
+                <version>${rdf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
@@ -143,61 +143,61 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.3.3</version>
+                <version>4.5.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-cache</artifactId>
-                <version>4.3.3</version>
+                <version>4.5.2</version>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-rdfxml</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-rdfxml</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-ntriples</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-ntriples</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-nquads</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-nquads</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-turtle</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-turtle</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-trig</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-trig</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrdf.sesame</groupId>
-                <artifactId>sesame-rio-rdfjson</artifactId>
-                <version>${sesame.version}</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-rdfjson</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.jsonld-java</groupId>
-                <artifactId>jsonld-java-sesame</artifactId>
-                <version>0.3</version>
+                <groupId>org.eclipse.rdf4j</groupId>
+                <artifactId>rdf4j-rio-jsonld</artifactId>
+                <version>${rdf4j.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            <dependency>
+            <!-- dependency> Disable until updated Semargl available
                 <groupId>org.semarglproject</groupId>
                 <artifactId>semargl-sesame</artifactId>
                 <version>0.6.1</version>
                 <scope>runtime</scope>
-            </dependency>
+            </dependency -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
@@ -227,13 +227,13 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>16.0.1</version>
+                <version>19.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/sesame-vocab-builder
+++ b/sesame-vocab-builder
@@ -6,9 +6,11 @@
 #     chmod +x sesame-vocab-builder
 #
 
-if [ ! -d "vocab-builder-cli/target/appassembler/bin" ]; then
-    mvn -quiet clean install
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ ! -d "${DIR}/vocab-builder-cli/target/appassembler/bin" ]; then
+    (cd ${DIR} && mvn -quiet clean install -DskipTests)
 fi
 
-chmod u+x vocab-builder-cli/target/appassembler/bin/*
-vocab-builder-cli/target/appassembler/bin/sesame-vocab-builder "$@"
+chmod u+x `ls ${DIR}/vocab-builder-cli/target/appassembler/bin/*`
+$DIR/vocab-builder-cli/target/appassembler/bin/sesame-vocab-builder "$@"

--- a/vocab-builder-cli/pom.xml
+++ b/vocab-builder-cli/pom.xml
@@ -121,44 +121,44 @@
 
         <!-- RDF Formats -->
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-rdfxml</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfxml</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-ntriples</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-ntriples</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-nquads</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-nquads</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-turtle</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-turtle</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-trig</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-trig</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-rdfjson</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfjson</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.jsonld-java</groupId>
-            <artifactId>jsonld-java-sesame</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-jsonld</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
+        <!-- dependency> Disabled until updated version available
             <groupId>org.semarglproject</groupId>
             <artifactId>semargl-sesame</artifactId>
             <scope>runtime</scope>
-        </dependency>
+        </dependency -->
     </dependencies>
 </project>

--- a/vocab-builder-core/pom.xml
+++ b/vocab-builder-core/pom.xml
@@ -27,12 +27,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-model</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-api</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -59,45 +59,45 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-rdfxml</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfxml</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-ntriples</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-ntriples</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-nquads</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-nquads</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-turtle</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-turtle</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-trig</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-trig</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-rdfjson</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfjson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.jsonld-java</groupId>
-            <artifactId>jsonld-java-sesame</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-jsonld</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
+        <!-- dependency> Disabled until updated version available
             <groupId>org.semarglproject</groupId>
             <artifactId>semargl-sesame</artifactId>
             <scope>test</scope>
-        </dependency>
+        </dependency-->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/AbstractVocabSpecificTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/AbstractVocabSpecificTest.java
@@ -9,9 +9,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.openrdf.model.util.GraphUtilException;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.rio.RDFParseException;
+import org.eclipse.rdf4j.model.util.GraphUtilException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
 
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderCompileTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderCompileTest.java
@@ -9,8 +9,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.openrdf.model.util.GraphUtilException;
-import org.openrdf.rio.RDFParseException;
+import org.eclipse.rdf4j.model.util.GraphUtilException;
+import org.eclipse.rdf4j.rio.RDFParseException;
 
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderPrefixTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderPrefixTest.java
@@ -7,8 +7,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.openrdf.model.util.GraphUtilException;
-import org.openrdf.rio.RDFParseException;
+import org.eclipse.rdf4j.model.util.GraphUtilException;
+import org.eclipse.rdf4j.rio.RDFParseException;
 
 import java.io.File;
 import java.io.IOException;

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderResourceBundleTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderResourceBundleTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.openrdf.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParseException;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabBuilderTest.java
@@ -13,17 +13,17 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Model;
-import org.openrdf.model.URI;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.LinkedHashModel;
-import org.openrdf.model.impl.ValueFactoryImpl;
-import org.openrdf.model.vocabulary.*;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.rio.RDFParserRegistry;
-import org.openrdf.rio.Rio;
-import org.openrdf.rio.UnsupportedRDFormatException;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.*;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParserRegistry;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -59,7 +59,7 @@ public class VocabBuilderTest {
                 // Ignore to drop this format from the list
             }
         }
-        assertFalse("No RDFFormats found with RDFParser implementations on classpath", result.isEmpty());
+        assertFalse("No RDFFormats found with RDFParser and RDFWriter implementations on classpath", result.isEmpty());
         return result;
     }
 
@@ -68,15 +68,15 @@ public class VocabBuilderTest {
 
     private Path testDir;
 
-    private URI testOntologyUri;
+    private IRI testOntologyUri;
 
-    private URI testProperty1;
+    private IRI testProperty1;
 
-    private URI testProperty2;
+    private IRI testProperty2;
 
-    private URI testProperty3;
+    private IRI testProperty3;
 
-    private URI testProperty4;
+    private IRI testProperty4;
 
     private Literal testProperty1Description;
 
@@ -93,6 +93,7 @@ public class VocabBuilderTest {
     private Path inputPath;
 
     public VocabBuilderTest(RDFFormat format) {
+    	System.out.println("Running VocabBuilderTest for format: " + format);
         this.format = format;
     }
 
@@ -100,14 +101,14 @@ public class VocabBuilderTest {
     public void setUp() throws Exception {
         testDir = tempDir.newFolder("vocabbuildertest").toPath();
 
-        ValueFactory vf = ValueFactoryImpl.getInstance();
+        ValueFactory vf = SimpleValueFactory.getInstance();
 
         String ns = "http://example.com/ns/ontology#";
-        testOntologyUri = vf.createURI(ns);
-        testProperty1 = vf.createURI(ns, "property1");
-        testProperty2 = vf.createURI(ns, "property_2");
-        testProperty3 = vf.createURI(ns, "property-3");
-        testProperty4 = vf.createURI(ns, "propertyLocalised4");
+        testOntologyUri = vf.createIRI(ns);
+        testProperty1 = vf.createIRI(ns, "property1");
+        testProperty2 = vf.createIRI(ns, "property_2");
+        testProperty3 = vf.createIRI(ns, "property-3");
+        testProperty4 = vf.createIRI(ns, "propertyLocalised4");
         testProperty1Description = vf.createLiteral("property 1 description");
         testProperty2Description = vf.createLiteral("property 2 description");
         testProperty3Description = vf.createLiteral("property 3 description");
@@ -156,7 +157,7 @@ public class VocabBuilderTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Files.copy(javaFilePath, out);
         String result = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        assertTrue(result.contains(testProperty4DescriptionFr.getLabel()));
+        assertTrue(result, result.contains(testProperty4DescriptionFr.getLabel()));
         assertFalse(result.contains(testProperty4DescriptionEn.getLabel()));
         assertTrue(result.contains("\"property_2\""));
         assertTrue(result.contains("\"property-3\""));

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabularyBuilderSpecialTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/VocabularyBuilderSpecialTest.java
@@ -54,8 +54,8 @@ public class VocabularyBuilderSpecialTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Files.copy(javaFilePath, out);
         String result = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        assertTrue(result.contains("public static final URI hasTarget"));
-        assertTrue(result.contains("public static final URI _default"));
+        assertTrue(result.contains("public static final IRI hasTarget"));
+        assertTrue(result.contains("public static final IRI _default"));
     }
 
 }

--- a/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/vocabularies/FoafVocabTest.java
+++ b/vocab-builder-core/src/test/java/com/github/tkurz/sesame/vocab/test/vocabularies/FoafVocabTest.java
@@ -2,7 +2,7 @@ package com.github.tkurz.sesame.vocab.test.vocabularies;
 
 import com.github.tkurz.sesame.vocab.test.AbstractVocabSpecificTest;
 import org.junit.Assume;
-import org.openrdf.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFFormat;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/vocab-builder-maven-plugin/pom.xml
+++ b/vocab-builder-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.4</version>
                 <configuration>
                     <goalPrefix>vocab-builder</goalPrefix>
                 </configuration>
@@ -90,45 +90,45 @@
 
         <!-- RDF Formats -->
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-rdfxml</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfxml</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-ntriples</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-ntriples</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-nquads</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-nquads</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-turtle</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-turtle</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-trig</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-trig</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-rdfjson</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-rdfjson</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.jsonld-java</groupId>
-            <artifactId>jsonld-java-sesame</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-jsonld</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
+        <!-- dependency> Disabled until updated version available
             <groupId>org.semarglproject</groupId>
             <artifactId>semargl-sesame</artifactId>
             <scope>runtime</scope>
-        </dependency>
+        </dependency-->
 
         <!-- Tests -->
         <dependency>


### PR DESCRIPTION
Convert from Sesame to RDF4J, fix some deprecations in the maven plugin, and make it possible to run sesame-vocab-builder from other working directories.

Signed-off-by: Peter Ansell p_ansell@yahoo.com
